### PR TITLE
imputation strategies

### DIFF
--- a/R/impute.R
+++ b/R/impute.R
@@ -228,32 +228,3 @@ strategies <- function(...){
     pkg_strats[["MAR"]] <- strategy_MAR
     return(pkg_strats)
 }
-
-
-
-
-strategy_MAR <- function(pars_group, pars_ref, index_mar){
-    return(pars_group)
-}
-
-strategy_JR <- function(pars_group, pars_ref, index_mar){
-    mu <- pars_group$mu
-    mu[!index_mar] <- pars_ref$mu[!index_mar]
-    pars <- list(
-        mu = mu,
-        sigma = pars_group$sigma  # TODO
-    )
-    return(pars)
-}
-
-strategy_CR <- function(pars_group, pars_ref, index_mar){
-    # TODO
-}
-
-strategy_CIR <- function(pars_group, pars_ref, index_mar){
-    # TODO
-}
-
-strategy_LMCF <- function(pars_group, pars_ref, index_mar){
-    # TODO
-}

--- a/tests/testthat/test-strategies.R
+++ b/tests/testthat/test-strategies.R
@@ -1,0 +1,115 @@
+test_that("adjusted unconditional covariance matrix for JR and CIR is correct (same_cov = TRUE)", {
+  
+  sigma_group <- sigma_ref = diag(rep(1,3)) + 0.5
+  index_mar <- c(TRUE, TRUE, FALSE)
+  
+  expect_equal(compute_sigma(sigma_group, sigma_ref, index_mar), sigma_ref)
+  
+})
+
+test_that("adjusted unconditional covariance matrix for JR and CIR is correct (same_cov = FALSE)", {
+  
+  sigma_group <- sigma_ref <- diag(rep(1,3)) + 0.5
+  sigma_ref <- diag(rep(1,3)) + 0.2
+  index_mar <- c(TRUE, TRUE, FALSE)
+  
+  sigma_strategy <- compute_sigma(sigma_group, sigma_ref, index_mar)
+  
+  expect_false(identical(sigma_strategy, sigma_ref))
+  expect_false(identical(sigma_strategy, sigma_group))
+  expect_false(sigma_strategy[3,3] == sigma_ref[3,3])
+  expect_equal(sigma_strategy[1:2,1:2], sigma_group[1:2,1:2])
+  expect_false(identical(sigma_strategy[1:2,3], sigma_group[1:2,3]))
+  expect_false(identical(sigma_strategy[1:2,3], sigma_ref[1:2,3]))
+  expect_true(isSymmetric(sigma_strategy))
+  
+})
+
+test_that("adjusted unconditional covariance matrix for JR and CIR is correct (all MAR data)", {
+  
+  sigma_group <- sigma_ref <- diag(rep(1,3)) + 0.5
+  sigma_ref <- diag(rep(1,3)) + 0.2
+  index_mar <- c(TRUE, TRUE, TRUE)
+  
+  expect_equal(compute_sigma(sigma_group, sigma_ref, index_mar), sigma_group)
+  
+})
+
+test_that("adjusted unconditional covariance matrix for JR and CIR is correct (all non-MAR data)", {
+  
+  sigma_group <- sigma_ref <- diag(rep(1,3)) + 0.5
+  sigma_ref <- diag(rep(1,3)) + 0.2
+  index_mar <- c(FALSE, FALSE, FALSE)
+  
+  expect_equal(compute_sigma(sigma_group, sigma_ref, index_mar), sigma_ref)
+  
+})
+
+test_that("mean and covariance under CIR are as expected", {
+  
+  pars_group <- list(
+    mu = c(1, 3, 5),
+    sigma = diag(rep(1,3))
+  )
+  pars_ref <- list(
+    mu = c(2, 6, 10),
+    sigma = diag(rep(1,3))
+  )
+  
+  index_mar <- c(TRUE, FALSE, FALSE)
+  
+  expect_equal(
+    strategy_CIR(pars_group, pars_ref, index_mar),
+    list(
+      mu = c(1, 5, 9),
+      sigma = diag(rep(1,3))
+    )
+  )
+  
+})
+
+test_that("mean and covariance under LMCF are as expected", {
+  
+  pars_group <- list(
+    mu = c(1, 3, 5),
+    sigma = diag(rep(1,3))
+  )
+  pars_ref <- list(
+    mu = c(2, 6, 10),
+    sigma = diag(rep(1,3))
+  )
+  
+  index_mar <- c(TRUE, FALSE, FALSE)
+  
+  expect_equal(
+    strategy_LMCF(pars_group, pars_ref, index_mar),
+    list(
+      mu = c(1, 1, 1),
+      sigma = diag(rep(1,3))
+    )
+  )
+  
+})
+
+test_that("mean and covariance under JR are as expected", {
+  
+  pars_group <- list(
+    mu = c(1, 3, 5),
+    sigma = diag(rep(1,3))
+  )
+  pars_ref <- list(
+    mu = c(2, 6, 10),
+    sigma = diag(rep(1,3))
+  )
+  
+  index_mar <- c(TRUE, FALSE, FALSE)
+  
+  expect_equal(
+    strategy_JR(pars_group, pars_ref, index_mar),
+    list(
+      mu = c(1, 6, 10),
+      sigma = diag(rep(1,3))
+    )
+  )
+  
+})


### PR DESCRIPTION
Hi @gowerc,

1. Implemented `compute_sigma()` function needed for CIR and JR strategies. Included some unit testing
2. Implemented CR, CIR, LMCF strategies. Updated the JR strategy with new `compute_sigma()` implementation. Included some unit testing.

The LMCF strategy is not complete: it is missing the case where `index_mar` is always FALSE for any visit. Indeed, in this case the mean under LMCF assumption should be equal to what? Maybe his baseline value or the mean baseline value for his arm?

Best,
Alessandro