### PR TITLE
rstan_test_failure

### DIFF
--- a/tests/testthat/test-mcmc.R
+++ b/tests/testthat/test-mcmc.R
@@ -109,7 +109,7 @@ test_that("Posterior mean of mcmc equals (restricted) ML estimates", {
 
     set.seed(101)
 
-    n <- 100
+    n <- 500
     nv <- 2
 
     covars <- tibble(


### PR DESCRIPTION
Addresses #73.

In my machine the test was successfull. However I increased the sample size of the test data to make more likely that the posterior mean of the parameters equals REML estimates from MMRM. I hope now the test will be passed also in other machines.