### PR TITLE
initial values for BFGS optimizer

### DIFF
--- a/R/mmrm.R
+++ b/R/mmrm.R
@@ -207,29 +207,35 @@ fit_mmrm <- function(
 #' Title
 #'
 #' @param optimizer TODO
-#' @param initial_values TODO
 #' @param ... TODO
-fit_mmrm_multiopt <- function(..., optimizer, initial_values = NULL) {
+fit_mmrm_multiopt <- function(..., optimizer) {
 
     assert_that(
-        is.character(optimizer),
+        is.character(optimizer) | is.list(optimizer),
         length(optimizer) >= 1
     )
 
-    if(is.null(initial_values)) {
-        initial_values <- vector(mode = "list", length = length(optimizer))
-        names(initial_values) <- optimizer
+    if (is.list(optimizer)) {
+        for (i in seq_len(length(optimizer))) {
+            if (!is.null(optimizer[[i]])) {
+                assert_that(
+                    all(c("beta", "theta") %in% names(optimizer[[i]]))
+                )
+                optimizer[[i]] <- optimizer[[i]][c("beta", "theta")]
+            }
+        }
     }
 
-    assert_that(
-        is.list(initial_values),
-        length(initial_values) == length(optimizer),
-        all(names(initial_values) == optimizer)
-    )
+    if (is.character(optimizer)) {
+        initial_values <- lapply(optimizer, function(x) NULL)
+        names(initial_values) <- optimizer
+    } else {
+        initial_values <- optimizer
+    }
 
-    for (i in seq.int(1, length(optimizer))) {
-        opt <- optimizer[i]
-        init_vals <- initial_values[[opt]]
+    for (i in seq_len(length(initial_values))) {
+        opt <- names(initial_values)[[i]]
+        init_vals <- initial_values[[i]]
         fit <- fit_mmrm(..., initial_values = init_vals, optimizer = opt)
         if (!fit$failed) break
     }

--- a/man/fit_mmrm_multiopt.Rd
+++ b/man/fit_mmrm_multiopt.Rd
@@ -4,14 +4,12 @@
 \alias{fit_mmrm_multiopt}
 \title{Title}
 \usage{
-fit_mmrm_multiopt(..., optimizer, initial_values = NULL)
+fit_mmrm_multiopt(..., optimizer)
 }
 \arguments{
 \item{...}{TODO}
 
 \item{optimizer}{TODO}
-
-\item{initial_values}{TODO}
 }
 \description{
 Title

--- a/man/get_mmrm_sample.Rd
+++ b/man/get_mmrm_sample.Rd
@@ -4,7 +4,7 @@
 \alias{get_mmrm_sample}
 \title{TODO}
 \usage{
-get_mmrm_sample(ids, longdata, method, optimizer, initial_values = NULL)
+get_mmrm_sample(ids, longdata, method, optimizer)
 }
 \arguments{
 \item{ids}{TODO}
@@ -14,8 +14,6 @@ get_mmrm_sample(ids, longdata, method, optimizer, initial_values = NULL)
 \item{method}{TODO}
 
 \item{optimizer}{TODO}
-
-\item{initial_values}{TODO}
 }
 \description{
 TODO

--- a/tests/testthat/test-mmrm.R
+++ b/tests/testthat/test-mmrm.R
@@ -112,7 +112,6 @@ test_mmrm_numeric <- function(dat, formula_expr, same_cov, scale = FALSE) {
         cov_struct = "us",
         REML = TRUE,
         same_cov = same_cov,
-        initial_values = NULL,
         optimizer = "BFGS"
     )
 
@@ -187,7 +186,7 @@ vars <- ivars(
     strategy = "strategy"
 )
 
-formula <- outcome ~ sex + age + visit*group
+formula <- outcome ~ sex + age + visit * group
 designmat <- as_model_df(dat = dat, formula)
 
 args_default <- list(
@@ -367,6 +366,7 @@ test_that("MMRM model with multiple optimizers has expected output", {
     ###### Single optimiser
     args <- args_default
     args$optimizer <- "BFGS"
+    args$initial_values <- NULL
 
     args$same_cov <- FALSE
 
@@ -442,3 +442,62 @@ test_that("MMRM returns expected estimates under different model specifications"
     }
 
 })
+
+
+
+
+
+
+
+test_that("initial values speed up BFGS", {
+
+    set.seed(315)
+    sigma <- as_covmat(c(5, 3, 8), c(0.4, 0.6, 0.3))
+
+    dat <- get_sim_data(n = 200, sigma)
+
+    vars <- ivars(
+        subjid = "id",
+        covariates = c("group", "sex", "visit * group")
+    )
+
+    frm <- as_simple_formula(vars)
+    model_df <- as_model_df(dat = dat, frm = frm)
+
+    x <- time_it({
+        fit <- fit_mmrm_multiopt(
+            designmat = model_df[, -1, drop = FALSE],
+            outcome = as.data.frame(model_df)[, 1],
+            subjid = dat[[vars$subjid]],
+            visit = dat[[vars$visit]],
+            group = dat[[vars$group]],
+            cov_struct = "us",
+            REML = TRUE,
+            same_cov = TRUE,
+            optimizer = "BFGS"
+        )
+    })
+
+    y <- time_it({
+        fit2 <- fit_mmrm_multiopt(
+            designmat = model_df[, -1, drop = FALSE],
+            outcome = as.data.frame(model_df)[, 1],
+            subjid = dat[[vars$subjid]],
+            visit = dat[[vars$visit]],
+            group = dat[[vars$group]],
+            cov_struct = "us",
+            REML = TRUE,
+            same_cov = TRUE,
+            optimizer = list(
+                BFGS = fit[c("beta", "theta")]
+            )
+        )
+    })
+
+    expect_true(
+        (as.numeric(x) * 0.5) > as.numeric(y)
+    )
+})
+
+
+


### PR DESCRIPTION
- We do not provide initial values for the first optimizer L-BFGS-G, to avoid error messages due to unfeasible initialization
- We do provide initial values for BFGS. This helps convergence and running times
- This feature applies to bootstrap and jackknife. I think we should apply it also to `approxbayes`. Do you know how to best do it? I think we need to use the argument `first_sample_orig = TRUE` but in this way the first sample will be on the original dataset. 

@gowerc Please let me know if you like how I set it up. I decided to provide a list of initial values, one for each optimizer. e.g. `initial_values = list("L-BFGS-G" = NULL, "BFGS" = 3)`.

Addresses #114 