### PR TITLE
pval = 1 when > 1 in bootstrap percentile

### DIFF
--- a/R/pool.R
+++ b/R/pool.R
@@ -374,7 +374,7 @@ pool_bootstrap_percentile <- function(est, conf.level, alternative) {
         est = est_orig,  # First estimate should be original dataset
         ci = ci,
         se = NA,
-        pvalue = min(pvals[index]) * length(pvals[index])
+        pvalue = min(min(pvals[index]) * length(pvals[index]), 1)
     )
     return(ret)
 }

--- a/tests/testthat/test-pool.R
+++ b/tests/testthat/test-pool.R
@@ -333,6 +333,28 @@ test_that("Results of bootstrap percentiles when n_samples = 0 or 1", {
 }
 )
 
+test_that("Bootstrap percentile does not return two-sided p-value larger than 1 when number of positive and negative estimates is equal", {
+    best <- c(1,-1,-2,3,2,1,-4,-3,2)
+
+    x1 <- quantile(best[-1], 0.10, type = 6)[[1]]
+    x2 <- quantile(best[-1], 0.90, type = 6)[[1]]
+    pval <- (sum(best[-1] < 0) + 1 ) / length(best)
+    expected <- list(
+        est = best[1],
+        ci = c(x1, x2),
+        se = NA,
+        pvalue = 1 # 2*pval is larger than one in this case: (n_samples+2)/(n_samples+1)
+    )
+    observed <- pool_internal.bootstrap(
+        list(est = best),
+        conf.level = 0.80,
+        alternative = "two.sided",
+        type =  "percentile"
+    )
+    expect_equal(observed, expected)
+
+})
+
 
 
 


### PR DESCRIPTION
The formula to get the two-sided pvalue in percentile bootstrap is the following: the formula for the pvalue is: 

```
2*min( (#theta <0 + 1)/(B+1), (#theta >0 + 1)/(B+1)  )
``` 

The pvalue has its upper limit when:

```
#theta <0 = #theta >0 = B/2
```

In this case the pvalue is 

```
2*(B/2 + 1)/(B+1) = .. = (B+2)/(B+1)
``` 

which is above 1. Of course, for large `B` then this is kind of negligible. We modify the pvalue being equal to `pval <- min(pval, 1)`.