### PR TITLE
Undo pkgdown job permissions

### DIFF
--- a/.github/workflows/packagedown.yaml
+++ b/.github/workflows/packagedown.yaml
@@ -8,11 +8,9 @@ on:
 
 jobs:
   docs:
-    permissions:
-      pages: write
     name: Pkgdown Docs
     uses: insightsengineering/r.pkg.template/.github/workflows/pkgdown.yaml@main
     secrets:
-      REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       install-system-dependencies: true


### PR DESCRIPTION
The token should be able to write docs as-is, given that the repo settings have changed.