### PR TITLE
added warning to fill_locf

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -59,7 +59,7 @@ locf <- function(x) {
 #' ## Missing First Values
 #'
 #' The `fill_locf()` function performs last observation carried forward imputation.
-#' A natural consquence of this is that it is unable to impute missing observations if the
+#' A natural consequence of this is that it is unable to impute missing observations if the
 #' observation is the first value.
 #' A common request is for this function to impute the first value if it is missing
 #' however doing so risks silent errors in the case of time varying covariates.

--- a/R/expand.R
+++ b/R/expand.R
@@ -60,11 +60,12 @@ locf <- function(x) {
 #'
 #' The `fill_locf()` function performs last observation carried forward imputation.
 #' A natural consequence of this is that it is unable to impute missing observations if the
-#' observation is the first value.
-#' A common request is for this function to impute the first value if it is missing
-#' however doing so risks silent errors in the case of time varying covariates.
-#' The current recommendation for dealing with this problem is to first use `expand_locf()` on just
-#' the visits and time varying covariates and then merge on the baseline covariates afterwards i.e.
+#' observation is the first value for a given subject / grouping.
+#' These values are deliberately not imputed as doing so risks silent errors in the case of time
+#' varying covariates.
+#' One solution is to first use `expand_locf()` on just
+#' the visit variable and time varying covariates and then merge on the baseline covariates
+#' afterwards i.e.
 #'
 #' ```
 #' library(dplyr)
@@ -75,7 +76,7 @@ locf <- function(x) {
 #'     visit = c("vis1", "vis2", "vis3")
 #' )
 #'
-#' dat_filled %>%
+#' dat_filled <- dat_expanded %>%
 #'     left_join(baseline_covariates, by = "subject")
 #' ```
 #'

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -52,7 +52,7 @@ will be returned in the original sort order however.
 \subsection{Missing First Values}{
 
 The \code{fill_locf()} function performs last observation carried forward imputation.
-A natural consquence of this is that it is unable to impute missing observations if the
+A natural consequence of this is that it is unable to impute missing observations if the
 observation is the first value.
 A common request is for this function to impute the first value if it is missing
 however doing so risks silent errors in the case of time varying covariates.

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -53,11 +53,12 @@ will be returned in the original sort order however.
 
 The \code{fill_locf()} function performs last observation carried forward imputation.
 A natural consequence of this is that it is unable to impute missing observations if the
-observation is the first value.
-A common request is for this function to impute the first value if it is missing
-however doing so risks silent errors in the case of time varying covariates.
-The current recommendation for dealing with this problem is to first use \code{expand_locf()} on just
-the visits and time varying covariates and then merge on the baseline covariates afterwards i.e.\preformatted{library(dplyr)
+observation is the first value for a given subject / grouping.
+These values are deliberately not imputed as doing so risks silent errors in the case of time
+varying covariates.
+One solution is to first use \code{expand_locf()} on just
+the visit variable and time varying covariates and then merge on the baseline covariates
+afterwards i.e.\preformatted{library(dplyr)
 
 dat_expanded <- expand(
     data = dat,
@@ -65,7 +66,7 @@ dat_expanded <- expand(
     visit = c("vis1", "vis2", "vis3")
 )
 
-dat_filled \%>\%
+dat_filled <- dat_expanded \%>\%
     left_join(baseline_covariates, by = "subject")
 }
 }

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -49,6 +49,26 @@ will be returned in the original sort order however.
 
 \code{expand_locf()} a simple composition function of \code{fill_locf()} and \code{expand()} i.e.
 \code{fill_locf(expand(...))}.
+\subsection{Missing First Values}{
+
+The \code{fill_locf()} function performs last observation carried forward imputation.
+A natural consquence of this is that it is unable to impute missing observations if the
+observation is the first value.
+A common request is for this function to impute the first value if it is missing
+however doing so risks silent errors in the case of time varying covariates.
+The current recommendation for dealing with this problem is to first use \code{expand_locf()} on just
+the visits and time varying covariates and then merge on the baseline covariates afterwards i.e.\preformatted{library(dplyr)
+
+dat_expanded <- expand(
+    data = dat,
+    subject = c("pt1", "pt2", "pt3", "pt4"),
+    visit = c("vis1", "vis2", "vis3")
+)
+
+dat_filled \%>\%
+    left_join(baseline_covariates, by = "subject")
+}
+}
 }
 \examples{
 \dontrun{

--- a/man/locf.Rd
+++ b/man/locf.Rd
@@ -14,6 +14,6 @@ Returns a vector after applied last observation carried forward imputation.
 }
 \examples{
 \dontrun{
-locf(c(NA, 1,2,3,NA,4)) # Returns c(NA, 1, 2, 3, 3, 4)
+locf(c(NA, 1, 2, 3, NA, 4)) # Returns c(NA, 1, 2, 3, 3, 4)
 }
 }

--- a/tests/testthat/test-expand.R
+++ b/tests/testthat/test-expand.R
@@ -74,13 +74,14 @@ test_that("fill_locf", {
         pt = c("a", "a", "a", "a", "b", "b", "b", "b"),
         v2 = c(1:8)
     )
-
-    df_actual <- fill_locf(
-        input_df,
-        vars = c("v1", "v2", "v3"),
-        group = "pt"
+    expect_warning(
+        df_actual <- fill_locf(
+            input_df,
+            vars = c("v1", "v2", "v3"),
+            group = "pt"
+        ),
+        regexp = "`v1`"
     )
-
     df_expected <- dplyr::tibble(
         v1 = c(NA,  1,    2,   2,  NA, 3,  3,   4),
         v3 = c(1, 2, 2, 3, 4, 5, 6, 7),
@@ -90,11 +91,20 @@ test_that("fill_locf", {
     expect_equal(df_actual, df_expected)
 
 
-    df_actual <- fill_locf(
-        input_df,
-        vars = c("v1", "v2", "v3")
-    )
 
+    input_df <- dplyr::tibble(
+        v1 = c(NA,  1,    2,   NA,  NA, 3,  NA,   4),
+        v3 = c(1, 2, NA, 3, 4, 5, 6, 7),
+        pt = c("a", "a", "a", "a", "b", "b", "b", "b"),
+        v2 = c(1:8)
+    )
+    expect_warning(
+        df_actual <- fill_locf(
+            input_df,
+            vars = c("v1", "v2", "v3")
+        ),
+        regexp = "`v1`"
+    )
     df_expected <- dplyr::tibble(
         v1 = c(NA,  1,    2,   2,  2, 3,  3,   4),
         v3 = c(1, 2, 2, 3, 4, 5, 6, 7),
@@ -105,20 +115,19 @@ test_that("fill_locf", {
 
 
 
-
-
     input_df <- dplyr::tibble(
         v1 = c(NA,  1,    2,   NA,  NA, 3,  NA,   4),
         pt = c("b", "b", "a", "a", "a", "a", "b", "b"),
         v2 = c(1:8)
     )
-
-    df_actual <- fill_locf(
-        input_df,
-        vars = c("v1", "v2"),
-        group = "pt"
+    expect_warning(
+        df_actual <- fill_locf(
+            input_df,
+            vars = c("v1", "v2"),
+            group = "pt"
+        ),
+        regexp = "`v1`"
     )
-
     df_expected <- dplyr::tibble(
         v1 = c(NA,  1,    2,   2,  2, 3,  1,   4),
         pt = c("b", "b", "a", "a", "a", "a", "b", "b"),
@@ -138,14 +147,12 @@ test_that("fill_locf", {
         srt2 = c(2,  1,   2,   1,   1,   1,   1,   1),
         v2 = c(1:8)
     )
-
     df_actual <- fill_locf(
         input_df,
         vars = c("v1", "v2"),
         group = "pt",
         order = c("srt1", "srt2")
     )
-
     df_expected <-  dplyr::tibble(
         v1 = c(4,   1,   2,   3,  4,  3,   4,  4),
         pt = c("b", "a", "a", "a", "b", "a", "b", "b"),
@@ -156,21 +163,49 @@ test_that("fill_locf", {
     expect_equal(df_actual, df_expected)
 
 
+
     input_df <- tibble(
         v1 = 1,
         v2 = 3
     )
-
     expect_error(fill_locf(input_df, vars = c("v1", "v2", "v3")), regexp = "`v3`")
     expect_error(fill_locf(input_df, vars = c("v1", "v2"), group = "v3"), regexp = "`v3`")
     expect_error(fill_locf(input_df, vars = c("v1", "v2"), order = "v3"), regexp = "`v3`")
 
+
+
+
+    input_df <- dplyr::tibble(
+        v1 = c(NA,  1,    2,   2,  2, 3,  3,   4),
+        v3 = c(1, 2, 2, 3, 4, 5, 6, 7),
+        pt = c(NA, "a", "a", "a", "b", "b", "b", "b"),
+        c1 = c(NA, 2:8),
+        v2 = c(1:8)
+    )
+    expect_warning(
+        df_actual <- fill_locf(
+            input_df,
+            vars = c("v1", "v2", "c1"),
+            group = "pt",
+            order = c("pt", "c1")
+        ),
+        regexp = "`v1`, `c1`"
+    )
+    df_expected <- dplyr::tibble(
+        v1 = c(NA,  1,    2,   2,  2, 3,  3,   4),
+        v3 = c(1, 2, 2, 3, 4, 5, 6, 7),
+        pt = c(NA, "a", "a", "a", "b", "b", "b", "b"),
+        c1 = c(NA, 2:8),
+        v2 = c(1:8)
+    )
+    expect_equal(df_actual, df_expected)
 })
 
 
 
 
-test_that("expand_locf",{
+test_that("expand_locf", {
+
     input_df <- dplyr::tibble(
         c1 = c("A", "B", "A", "C"),
         c2 = c("A", "A", "B", "B"),
@@ -254,14 +289,18 @@ test_that("fill_locf - works with list columns", {
     input_df <- dplyr::tibble(
         pt = c("a", "a", "b", "b", "b"),
         srt1 = c(1, 2, 1, 2, 3),
-        list_val = list(c(1, 1), NA, NA, c(4, 4,4,4), NA)
+        list_val = list(c(1, 1), NA, NA, c(4, 4, 4, 4), NA)
     )
-    df_actual <- fill_locf(
-        input_df,
-        vars = "list_val",
-        group = "pt",
-        order = "srt1"
+    expect_warning(
+        df_actual <- fill_locf(
+            input_df,
+            vars = "list_val",
+            group = "pt",
+            order = "srt1"
+        ),
+        regexp = "`list_val`"
     )
+
     df_expected <- dplyr::tibble(
         pt = c("a", "a", "b", "b", "b"),
         srt1 = c(1, 2, 1, 2, 3),
@@ -275,7 +314,7 @@ test_that("fill_locf - works with list columns", {
     input_df <- dplyr::tibble(
         pt = c("a", "a", "b", "b", "b", "b", "b"),
         srt1 = c(1, 2, 1, 2, 3, 4, 5),
-        list_val = list(NA, mod1, mod1, NA, iris, NA, NA)
+        list_val = list(mod1, mod1, mod1, NA, iris, NA, NA)
     )
     df_actual <- fill_locf(
         input_df,
@@ -286,7 +325,7 @@ test_that("fill_locf - works with list columns", {
     df_expected <- dplyr::tibble(
         pt = c("a", "a", "b", "b", "b", "b", "b"),
         srt1 = c(1, 2, 1, 2, 3, 4, 5),
-        list_val = list(NA, mod1, mod1, mod1, iris, iris, iris)
+        list_val = list(mod1, mod1, mod1, mod1, iris, iris, iris)
     )
     expect_equal(df_actual, df_expected)
 })
@@ -304,12 +343,16 @@ test_that("fill_locf works with factors", {
         v2 = c(1, 2, 3, 4, NA, 6, NA, 8)
     )
 
-    df_actual <- fill_locf(
-        input_df,
-        vars = c("v1", "myfac1"),
-        group = "pt",
-        order = c("srt1", "srt2")
+    expect_warning(
+        df_actual <- fill_locf(
+            input_df,
+            vars = c("v1", "myfac1"),
+            group = "pt",
+            order = c("srt1", "srt2")
+        ),
+        regexp = "`v1`, `myfac1`"
     )
+
 
     df_expected <- data.frame(
         v1 = c(NA, 1, 2, 2, NA, 3, 3, 4),
@@ -334,11 +377,14 @@ test_that("fill_locf works with factors", {
         v2 = c(1, 2, 3, 4, NA, 6, NA, 8)
     )
 
-    df_actual <- fill_locf(
-        input_df,
-        vars = c("v1", "myfac1"),
-        group = "pt",
-        order = c("srt1", "srt2")
+    expect_warning(
+        df_actual <- fill_locf(
+            input_df,
+            vars = c("v1", "myfac1"),
+            group = "pt",
+            order = c("srt1", "srt2")
+        ),
+        regexp = "`v1`, `myfac1`"
     )
 
     df_expected <- data.frame(


### PR DESCRIPTION
Closes #305

Example of warning:

```
> df_actual <- fill_locf(
+         input_df,
+         vars = c("v1", "myfac1"),
+         group = "pt",
+         order = c("srt1", "srt2")
+     )
Warning message:
In fill_locf(input_df, vars = c("v1", "myfac1"), group = "pt", order = c("srt1",  :
  The following variables have missing values as their first value in one of more groups: `v1`, `myfac1`
 Please consult the man page for `fill_locf()` for further details / recommendations
```

@wolbersm , do you think this is sufficient with what you had in mind ? 