### PR TITLE
Use R 4.2.1 for validation

### DIFF
--- a/.github/workflows/validate_generic_master.yaml
+++ b/.github/workflows/validate_generic_master.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Create report 📃
     runs-on: ubuntu-latest
     container:
-      image: rocker/verse:4.1.1
+      image: rocker/verse:4.2.1
     # Set Github token permissions
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Because rbmi depends on mmrm which isn't available for R 4.1.1.
Closes https://github.com/insightsengineering/thevalidatoR/issues/58