### PR TITLE
Add unit test for blank data_ice

### DIFF
--- a/tests/testthat/test-longData.R
+++ b/tests/testthat/test-longData.R
@@ -1166,9 +1166,9 @@ test_that("Missing data_ices are handled correctly", {
 
     longdata <- longDataConstructor$new(dat, vars)
 
-    og <- longdata$clone(deep = TRUE)
+    original <- longdata$clone(deep = TRUE)
     longdata$set_strategies(dat_ice)
 
     # When using a blank data_ice, nothing in longdata should be updated
-    expect_equal(longdata, og)
+    expect_equal(longdata, original)
 })


### PR DESCRIPTION
Closes #460 

Adding unit test to prevent future regressions of issues where a blank `data_ice` object is provided. 