### PR TITLE
Update Docker Pipeline

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -65,5 +65,5 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}:${{ steps.vars.outputs.tag }}
           build-args: |
-          cache-from: type=registry,ref=user/app:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}:latest
           cache-to: type=inline


### PR DESCRIPTION
This PR attempts to address some short comings in the current docker build process namely:

- This enables the build to happen automatically when anything edits the docker folder (currently only runs on manual trigger or on bi-weekly schedule)
- Updated so that it will only push to "latest" if the push-event was on the main branch
- Removed the GHA caching code, I don't think this actually adds any value as we install binary packages now which is very quick and the article that was linked to about caching no longer exists, instead I've just included the defaults as recommend [here](https://docs.docker.com/build/ci/github-actions/cache/) 